### PR TITLE
Add useWorkspaceSettings config which toggles whether to update the font size in the workspace, rather than global, settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ You can configure the following settings:
 * **fontshortcuts.defaultFontSize**: The default editor font size used for a reset. (default: 15)
 * **fontshortcuts.defaultTerminalFontSize**: The default terminal font size used for a reset. (default: 15)
 * **fontshortcuts.step**: The step for each font size increment/decrement. (default: 1)
+* **fontshortcuts.useWorkspaceSettings**: Whether to use and update the editor font size from Workspace settings, rather than Global settings (default: false)
 
 ```json
 {
   "fontshortcuts.defaultFontSize": 15,
   "fontshortcuts.defaultTerminalFontSize": 15,
-  "fontshortcuts.step": 1
+  "fontshortcuts.step": 1,
+  "fontshortcuts.useWorkspaceSettings": false
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
           "type": "number",
           "description": "The increment or decrement step for a font size change",
           "default": 1
+        },
+        "fontshortcuts.useWorkspaceSettings": {
+          "type":  "boolean",
+          "description": "Whether to use and update the editor font size from Workspace settings, rather than Global settings",
+          "default": false
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,9 +24,10 @@ export function activate(context: ExtensionContext) {
     const step = config.get<number>("fontshortcuts.step");
     const newSize = Math.min(maxFontSize, Math.round(fontSize + step));
     const newLineHeight = Math.min(maxFontSize, Math.round(newSize * relativeLineHeight));
+    const useGlobalSettings = !config.get<boolean>("fontshortcuts.useWorkspaceSettings", false);
     if (newSize === fontSize) return;
-    if (! terminal) config.update(lineHeightProperty, newLineHeight, true);
-    return config.update(fontSizeType, newSize, true);
+    if (! terminal) config.update(lineHeightProperty, newLineHeight, useGlobalSettings);
+    return config.update(fontSizeType, newSize, useGlobalSettings);
   }
 
   async function decreaseFontSize(terminal: boolean) {
@@ -41,9 +42,10 @@ export function activate(context: ExtensionContext) {
     const step = config.get<number>("fontshortcuts.step");
     const newSize = Math.max(minFontSize, Math.round(fontSize - step));
     const newLineHeight = Math.min(maxFontSize, Math.round(newSize * relativeLineHeight));
+    const useGlobalSettings = !config.get<boolean>("fontshortcuts.useWorkspaceSettings", false);
     if (newSize === fontSize) return;
-    if (! terminal) config.update(lineHeightProperty, newLineHeight, true);
-    return config.update(fontSizeType, newSize, true);
+    if (! terminal) config.update(lineHeightProperty, newLineHeight, useGlobalSettings);
+    return config.update(fontSizeType, newSize, useGlobalSettings);
   }
 
   async function resetFontSize(terminal: boolean) {
@@ -63,10 +65,11 @@ export function activate(context: ExtensionContext) {
       maxFontSize,
       Math.round(defaultFontSize * relativeLineHeight)
     );
+    const useGlobalSettings = !config.get<boolean>("fontshortcuts.useWorkspaceSettings", false);
     if (defaultFontSize === null) {
       try {
-        if (! terminal) await config.update(lineHeightProperty, undefined, true);
-        return await config.update(fontSizeType, undefined, true);
+        if (! terminal) await config.update(lineHeightProperty, undefined, useGlobalSettings);
+        return await config.update(fontSizeType, undefined, useGlobalSettings);
       } catch (e) {
         // swallow errors
         return;
@@ -78,8 +81,8 @@ export function activate(context: ExtensionContext) {
       defaultFontSize >= minFontSize &&
       defaultFontSize <= maxFontSize
     ) {
-      if (! terminal) config.update(lineHeightProperty, defaultLineHeight, true);
-      return config.update(fontSizeType, defaultFontSize, true);
+      if (! terminal) config.update(lineHeightProperty, defaultLineHeight, useGlobalSettings);
+      return config.update(fontSizeType, defaultFontSize, useGlobalSettings);
     }
 
     window.showErrorMessage(


### PR DESCRIPTION
This is the addition of a `useWorkspaceSettings` config which reads and updates the font size from the workspace setting rather than global. Defaults to false to maintain existing behaviour when not set.

A note on motivation: I use a multi-monitor setup, and I like to have different font sizes on different monitors to adjust for resolution, screen size etc. This extension is great but it doesn't really work for my setup because it adjusts font size globally. With this additional config I can easily move windows (well, workspaces, but they are usually 1:1) around to different monitors and quickly adjust their font sizes individually without affecting the others.

---

Just a note on one perhaps slightly weird UX aspect to this -- when you set `useWorkspaceSettings: true` and use the extension, then later set `useWorkspaceSettings` back to false, it *appears* to no longer work. Why? Because the workspace setting which was already set overrides the global setting which is now being updated. 

A solution to this *might* be to automatically remove any workspace `editor.fontSize` setting whenever setting the global one, but that seems really wrong because it also breaks the ability to manually override the setting per-workspace, which users may want to do even while using this extension. Hence, there could be another config with toggles *this* behaviour on/off (probably default on) to compensate for that.

To be honest, though, it seems simplest to just leave it as it is. After all, I think it's most likely that people simply use this new setting either all the time or none of the time, and won't be switching back and forth. If it seems like a problem to you, let me know which of the above solutions (or another, better one) seems like the right one and I'll add it.